### PR TITLE
s3: allow use of instance profile

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -18,6 +18,7 @@ data "template_file" "repl_ptfe_config" {
     pg_netloc              = var.postgresql_address
     pg_dbname              = var.postgresql_database
     pg_extra_params        = var.postgresql_extra_params
+    aws_instance_profile   = var.aws_instance_profile ? "1" : "0"
     aws_access_key_id      = var.aws_access_key_id
     aws_secret_access_key  = var.aws_secret_access_key
     s3_bucket_name         = var.s3_bucket

--- a/data/es.json
+++ b/data/es.json
@@ -23,6 +23,9 @@
     "pg_extra_params": {
         "value": "${pg_extra_params}"
     },
+    "aws_instance_profile": {
+        "value": "${aws_instance_profile}"
+    },
     "aws_access_key_id": {
         "value": "${aws_access_key_id}"
     },

--- a/data/es_airgap.json
+++ b/data/es_airgap.json
@@ -23,6 +23,9 @@
     "pg_extra_params": {
         "value": "${pg_extra_params}"
     },
+    "aws_instance_profile": {
+        "value": "${aws_instance_profile}"
+    },
     "aws_access_key_id": {
         "value": "${aws_access_key_id}"
     },

--- a/variables.tf
+++ b/variables.tf
@@ -188,6 +188,12 @@ variable "repl_cidr" {
 
 ### ================================ External Services Support
 
+variable "aws_instance_profile" {
+  type        = string
+  description = "When set, use credentials from the AWS instance profile"
+  default     = false
+}
+
 variable "aws_access_key_id" {
   type        = string
   description = "AWS access key id to connect to s3 with"

--- a/variables.tf
+++ b/variables.tf
@@ -189,7 +189,7 @@ variable "repl_cidr" {
 ### ================================ External Services Support
 
 variable "aws_instance_profile" {
-  type        = string
+  type        = bool
   description = "When set, use credentials from the AWS instance profile"
   default     = false
 }


### PR DESCRIPTION
Allows us to specify that we want TFE to use the instance profile to obtain credentials for S3:

https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#aws_instance_profile

The module outputs the instance role, so we can attach additional policies granting S3 access:

https://github.com/hashicorp/terraform-aws-terraform-enterprise/blob/master/outputs.tf#L9-L11

For testing I've been using this the external-services module but it's also looking like I'll need to fork/revise a bit:

https://github.com/hashicorp/terraform-aws-terraform-enterprise/tree/master/modules/external-services